### PR TITLE
Allow disablig console.error with verbose init option

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,6 +31,7 @@ export interface IInitOptions {
   hostname?: string
   enableCompression?: boolean
   correlation?: ICorrelation
+  verbose?: boolean
 }
 
 export type SendLogOptionsType = Partial<Omit<IBodyLog, "content">>


### PR DESCRIPTION
The `console.error`s are now disabled if `LogFlake.verbose` option is set to `false`.

The default behavior has been kept as `verbose=true` 